### PR TITLE
Use replace instead of replaceAll

### DIFF
--- a/query/src/main/java/org/apache/accumulo/examples/wikisearch/iterator/BooleanLogicIterator.java
+++ b/query/src/main/java/org/apache/accumulo/examples/wikisearch/iterator/BooleanLogicIterator.java
@@ -680,7 +680,7 @@ public class BooleanLogicIterator implements SortedKeyValueIterator<Key,Value>, 
             continue;
           }
           String fValue = t.getValue().toString();
-          fValue = fValue.replaceAll("'", "");
+          fValue = fValue.replace("'", "");
           boolean negated = t.getOperator().equals("!=");
           
           if (!fName.startsWith(FIELD_NAME_PREFIX)) {


### PR DESCRIPTION
[ACCUMULO-4864](https://issues.apache.org/jira/browse/ACCUMULO-4864) - performance overhead is incurred by replaceAll() because it attempts to compile any regex expression. Using replace() instead when a regex is not utilized can save this performance overhead